### PR TITLE
[ESN-1100] Queue job to zip resources if package is dataset type

### DIFF
--- a/ckanext/downloadall/plugin.py
+++ b/ckanext/downloadall/plugin.py
@@ -58,7 +58,8 @@ class DownloadallPlugin(plugins.SingletonPlugin):
         # SO if package.json (not including Package Zip bits) remains the same
         # then we don't need to regenerate zip.
         if isinstance(entity, model.Package):
-            enqueue_update_zip(entity.name, entity.id, operation)
+            if entity.type == 'dataset':
+                enqueue_update_zip(entity.name, entity.id, operation)
         elif isinstance(entity, model.Resource):
             if entity.extras.get('downloadall_metadata_modified'):
                 # this is the zip of all the resources - no need to react to


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/ESN-1100)

## Description
<!--- Describe these changes in detail --->
This PR is to fix an issue with how the downloadall extension interacts with other extensions that use the package model.

In CKAN the package model can be used by several extensions to store metadata, the default type is "dataset". The showcase extensions creates packages with the type "showcase" and the harvest extension creates packages with the type "harvest".

Currently the downloadall extension creates a new ZIP resource for all packages. This can be an issue if extensions like showcase and harvest are not expecting the resource field to be set.

To fix this an if statement is added to check if the package type is "dataset" before the background job.