### PR TITLE
[OD-1632] Add force option to downloadall command

### DIFF
--- a/ckanext/downloadall/cli.py
+++ b/ckanext/downloadall/cli.py
@@ -88,20 +88,26 @@ def update_zip(dataset_ref, synchronous, force):
 @click.option(u'--synchronous', u'-s',
               help=u'Do it in the same process (not the worker)',
               is_flag=True)
-def update_all_zips(synchronous):
+@click.option(u'--force', u'-f',
+              help=u'Force generation of ZIP file',
+              is_flag=True)
+def update_all_zips(synchronous, force):
     u''' update-all-zips <package-name>
 
     Generates zip file for all datasets. It is done synchronously.'''
     context = {'model': model, 'session': model.Session}
     datasets = toolkit.get_action('package_list')(context, {})
+    skip_if_no_changes = True
+    if force:
+        skip_if_no_changes = False
     for i, dataset_name in enumerate(datasets):
         if synchronous:
             print('Processing dataset {}/{}'.format(i + 1, len(datasets)))
-            tasks.update_zip(dataset_name)
+            tasks.update_zip(dataset_name, skip_if_no_changes)
         else:
             print('Queuing dataset {}/{}'.format(i + 1, len(datasets)))
             toolkit.enqueue_job(
-                tasks.update_zip, [dataset_name],
+                tasks.update_zip, [dataset_name, skip_if_no_changes],
                 title=u'DownloadAll {operation} "{name}" {id}'.format(
                     operation='cli-requested', name=dataset_name,
                     id=dataset_name),

--- a/ckanext/downloadall/cli.py
+++ b/ckanext/downloadall/cli.py
@@ -61,15 +61,21 @@ def cli(ctx, config, *args, **kwargs):
 @click.option(u'--synchronous', u'-s',
               help=u'Do it in the same process (not the worker)',
               is_flag=True)
-def update_zip(dataset_ref, synchronous):
+@click.option(u'--force', u'-f',
+              help=u'Force generation of ZIP file',
+              is_flag=True)
+def update_zip(dataset_ref, synchronous, force):
     u''' update-zip <package-name>
 
     Generates zip file for a dataset, downloading its resources.'''
+    skip_if_no_changes = True
+    if force:
+        skip_if_no_changes = False
     if synchronous:
-        tasks.update_zip(dataset_ref)
+        tasks.update_zip(dataset_ref, skip_if_no_changes)
     else:
         toolkit.enqueue_job(
-            tasks.update_zip, [dataset_ref],
+            tasks.update_zip, [dataset_ref, skip_if_no_changes],
             title=u'DownloadAll {operation} "{name}" {id}'.format(
                 operation='cli-requested', name=dataset_ref,
                 id=dataset_ref),


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/OD-1632)

## Description
<!--- Describe these changes in detail --->
This PR adds a force option to the downloadall commands `update_all_zips` and `update_zip`.
The following are example commands:
```
downloadall -c /etc/ckan/development.ini update-all-zips --force
downloadall -c /etc/ckan/development.ini update-zip test-dataset --force
```

## Testing
Prerequisite: Downloadall extension should be previously installed.
- Go to ckanext-downloadall, checkout this PR, and install
```
. /usr/lib/ckan/default/bin/activate
cd /usr/lib/ckan/default/src/ckanext-download
git fetch
git checkout jguo144/OD-1632/2021-01-20/add-force-option
python setup.py develop
``` 
- Restart supervisor
```
sudo service supervisor restart
```
- Run the following command on an existing dataset with a downloadall button
```
downloadall -c /etc/ckan/development.ini update-zip test-dataset --force
```
- Check that the ZIP is regenerated in the background jobs log. The message `Skipping updating the zip - the datapackage.json is not changed sufficiently` should not appear if the force option is used.
```
2021-01-22 00:16:22,194 INFO  [rq.worker] *** Listening on ckan:ckan_sandbox:default...
2021-01-22 00:17:45,011 INFO  [rq.worker] ckan:ckan_sandbox:default: ckanext.downloadall.tasks.update_zip(u'santa-cruz-county-1', False) (07cdf297-9743-48e7-b64c-7cfcc47369c8)
2021-01-22 00:17:45,012 INFO  [ckan.lib.jobs] Worker rq:worker:ckanhost.15927 starts job 07cdf297-9743-48e7-b64c-7cfcc47369c8 from queue "default"
2021-01-22 00:17:49,847 DEBUG [ckanext.harvest.model] Harvest tables already exist
2021-01-22 00:17:49,894 DEBUG [ckanext.spatial.plugin] Setting up the spatial model
2021-01-22 00:17:49,900 DEBUG [ckanext.spatial.model.package_extent] Spatial tables already exist
2021-01-22 00:17:49,902 DEBUG [ckanext.pages.db] Pages table already exists
2021-01-22 00:17:49,905 DEBUG [ckanext.showcase.model] ShowcasePackageAssociation table already exists
2021-01-22 00:17:49,917 DEBUG [ckanext.showcase.model] ShowcaseAdmin table already exists
2021-01-22 00:17:51,065 DEBUG [ckanext.downloadall.tasks] Updating zip: santa-cruz-county-1
2021-01-22 00:17:51,077 DEBUG [ckanext.downloadall.tasks] Resource resource 5/5 skipped - is the zip itself
2021-01-22 00:17:51,120 DEBUG [ckanext.downloadall.tasks] Downloading resource 1/4: https://data.debtwatch.treasurer.ca.gov/api/views/39cm-igfa/rows.csv?accessType=DOWNLOAD
2021-01-22 00:17:51,513 DEBUG [ckanext.downloadall.tasks] Downloaded 314.2 KB, hash: 671ff212422f8168a5f5c814c8539af1
2021-01-22 00:17:51,513 DEBUG [ckanext.downloadall.tasks] Downloading resource 2/4: https://data.debtwatch.treasurer.ca.gov/api/views/39cm-igfa/rows.rdf?accessType=DOWNLOAD
2021-01-22 00:17:51,891 DEBUG [ckanext.downloadall.tasks] Downloaded 1.3 MB, hash: 1b9483eb68c1ae49a9ab9472a698b368
2021-01-22 00:17:51,891 DEBUG [ckanext.downloadall.tasks] Downloading resource 3/4: https://data.debtwatch.treasurer.ca.gov/api/views/39cm-igfa/rows.json?accessType=DOWNLOAD
2021-01-22 00:17:52,207 DEBUG [ckanext.downloadall.tasks] Downloaded 592.0 KB, hash: 1f545558a4883400e551bad0785ead6e
2021-01-22 00:17:52,207 DEBUG [ckanext.downloadall.tasks] Downloading resource 4/4: https://data.debtwatch.treasurer.ca.gov/api/views/39cm-igfa/rows.xml?accessType=DOWNLOAD
2021-01-22 00:17:52,553 DEBUG [ckanext.downloadall.tasks] Downloaded 1.1 MB, hash: ddc02e3811586900ea352518ff886d3f
2021-01-22 00:17:52,555 DEBUG [ckanext.downloadall.tasks] Added datapackage.json from /tmp/tmpuq2IaA
2021-01-22 00:17:52,556 INFO  [ckanext.downloadall.tasks] Zip created: /tmp/santa-cruz-county-1-lGRmJU.zip 299514 bytes
2021-01-22 00:17:52,559 DEBUG [ckanext.downloadall.tasks] Updating zip resource - santa-cruz-county-1
```