### PR TITLE
added modified date to each file inside the zip, as requested by CRD

### DIFF
--- a/ckanext/downloadall/tasks.py
+++ b/ckanext/downloadall/tasks.py
@@ -291,7 +291,7 @@ def download_resource_into_zip(url, filename, zipf):
     size = 0
     # Create a ZipInfo object for setting the file's modified date
     zip_info = zipfile.ZipInfo(filename)
-    # Set the modified date 
+    # Set the modified date
     zip_info.date_time = datetime.datetime.now().timetuple()[:6]
     zip_info.compress_type = zipfile.ZIP_DEFLATED
     try:

--- a/ckanext/downloadall/tasks.py
+++ b/ckanext/downloadall/tasks.py
@@ -5,6 +5,7 @@ import hashlib
 import math
 import copy
 import logging
+import datetime
 
 import requests
 import six
@@ -288,9 +289,14 @@ def download_resource_into_zip(url, filename, zipf):
 
     hash_object = hashlib.sha224()
     size = 0
+    # Create a ZipInfo object for setting the file's modified date
+    zip_info = zipfile.ZipInfo(filename)
+    # Set the modified date 
+    zip_info.date_time = datetime.datetime.now().timetuple()[:6]
+    zip_info.compress_type = zipfile.ZIP_DEFLATED
     try:
         # python3 syntax - stream straight into the zip
-        with zipf.open(filename, 'w') as zf:
+        with zipf.open(zip_info, 'w') as zf:
             for chunk in r.iter_content(chunk_size=128):
                 zf.write(chunk)
                 hash_object.update(chunk)

--- a/ckanext/downloadall/tasks.py
+++ b/ckanext/downloadall/tasks.py
@@ -267,7 +267,7 @@ def save_local_path_in_datapackage_resource(datapackage_resource, res,
 
 def download_resource_into_zip(url, filename, zipf):
     try:
-        r = requests.get(url, stream=True)
+        r = requests.get(url, stream=True, timeout=300)
         r.raise_for_status()
     except requests.ConnectionError:
         log.error('URL {url} refused connection. The resource will not'


### PR DESCRIPTION
Actual Results: 
Resource files have a Date modified date of 1/1/1900. The .json metadata files are not affected, it correctly matches the Dataset’s ‘Last Updated’ metadata field. 

Expected Results: 
All files downloaded have a Date modified that **matches the time that the file was downloaded**. 

Also added a timeout to the requests.get call as it was failing Lint validation